### PR TITLE
Ensure that expansion does not produce duplicate metric paths

### DIFF
--- a/src/dqe_idx_pg.erl
+++ b/src/dqe_idx_pg.erl
@@ -208,15 +208,17 @@ expand(Bucket, Globs) when
       is_binary(Bucket),
       is_list(Globs) ->
     {ok, QueryMap} = query_builder:glob_query(Bucket, Globs),
-    RowList = [begin
+    RowSets = [begin
                    T0 = erlang:system_time(),
-                   {ok, _Cols, Rows0} = pgapp:equery(Q, Vs),
-                   lager:debug("[dqe_idx:pg:expand/2]Query took ~pms: ~s <- ~p",
+                   {ok, _Cols, Rows} = pgapp:equery(Q, Vs),
+                   lager:debug("[dqe_idx:pg:expand/2] "
+                               "Query took ~p ms: ~s <- ~p",
                                [tdelta(T0), Q, Vs]),
-                   Rows0
+                   sets:from_list(Rows)
                end || {Q, Vs} <- QueryMap],
-    Rows = lists:flatten(RowList),
-    Metrics = [dproto:metric_from_list(M) || {M} <- Rows],
+
+    UniqueRows = lists:foldl(fun sets:union/2, sets:new(), RowSets),
+    Metrics = [dproto:metric_from_list(M) || {M} <- sets:to_list(UniqueRows)],
     {ok, {Bucket, Metrics}}.
 
 -spec add(Collection::binary(),

--- a/src/dqe_idx_pg.erl
+++ b/src/dqe_idx_pg.erl
@@ -220,6 +220,8 @@ expand(Bucket, Globs) when
                    sets:from_list(Rows)
                end || {Q, Vs} <- QueryMap],
 
+    %% Destructuring into [H | T] is safe since the cardinality of `RowSets' is
+    %% equal to that of `Globs'
     [H | T] = RowSets,
     UniqueRows = lists:foldl(fun sets:union/2, H, T),
     Metrics = [dproto:metric_from_list(M) || {M} <- sets:to_list(UniqueRows)],

--- a/src/dqe_idx_pg.erl
+++ b/src/dqe_idx_pg.erl
@@ -204,6 +204,9 @@ values(Collection, Metric, Namespace, Tag)
                 [tdelta(T0), Q, Vs]),
     {ok, strip_tpl(Rows)}.
 
+expand(Bucket, []) when is_binary(Bucket) ->
+    {ok, {Bucket, []}};
+
 expand(Bucket, Globs) when
       is_binary(Bucket),
       is_list(Globs) ->
@@ -217,7 +220,8 @@ expand(Bucket, Globs) when
                    sets:from_list(Rows)
                end || {Q, Vs} <- QueryMap],
 
-    UniqueRows = lists:foldl(fun sets:union/2, sets:new(), RowSets),
+    [H | T] = RowSets,
+    UniqueRows = lists:foldl(fun sets:union/2, H, T),
     Metrics = [dproto:metric_from_list(M) || {M} <- sets:to_list(UniqueRows)],
     {ok, {Bucket, Metrics}}.
 


### PR DESCRIPTION
I could not use a 'reduce' in the form of `foldl(fun sets:union/2, H, T)` in case the list is empty.

Also, I think that we should discuss a testing strategy here - would be nice to use meck to mock the postgres result for this case.  It would also be nice to test the raw sql instead of parsing the SQL for valid sql - does this sound like a good idea?  
