### PR TITLE
Exclude nulls from metric variants

### DIFF
--- a/eqc/query_builder_eqc.erl
+++ b/eqc/query_builder_eqc.erl
@@ -26,6 +26,9 @@ non_empty_list(T) ->
 bucket() ->
     non_empty_binary().
 
+namespace() ->
+    non_empty_binary().
+
 collection() ->
     non_empty_binary().
 
@@ -35,9 +38,12 @@ metric() ->
 lqry_metric() ->
     oneof([metric(), undefined]).
 
+tag_name() ->
+    non_empty_binary().
+
 tag() ->
     frequency(
-      [{10, {tag, non_empty_binary(), non_empty_binary()}},
+      [{10, {tag, tag_name(), non_empty_binary()}},
        {1,  {tag, <<>>, non_empty_binary()}}]).
 
 lookup() ->
@@ -96,6 +102,106 @@ prop_metric_variants() ->
         begin
             Fun = fun(C) ->
                 {ok, Q, _V} = ?M:metric_variants_query(Collection, Prefix),
+                {Res, _} = epgsql:parse(C, Q),
+                Res
+            end,
+            ok =:= with_connection(Fun)
+        end
+    ).
+
+prop_collections() ->
+    ?FORALL({}, {},
+        begin
+            Fun = fun(C) ->
+                {ok, Q, _V} = ?M:collections_query(),
+                {Res, _} = epgsql:parse(C, Q),
+                Res
+            end,
+            ok =:= with_connection(Fun)
+        end
+    ).
+
+prop_metrics() ->
+    ?FORALL({Collection}, {collection()},
+        begin
+            Fun = fun(C) ->
+                {ok, Q, _V} = ?M:metrics_query(Collection),
+                {Res, _} = epgsql:parse(C, Q),
+                Res
+            end,
+            ok =:= with_connection(Fun)
+        end
+    ).
+
+prop_namespaces() ->
+    ?FORALL({Collection}, {collection()},
+        begin
+            Fun = fun(C) ->
+                {ok, Q, _V} = ?M:namespaces_query(Collection),
+                {Res, _} = epgsql:parse(C, Q),
+                Res
+            end,
+            ok =:= with_connection(Fun)
+        end
+    ).
+
+prop_metric_namespaces() ->
+    ?FORALL({Collection, Metric}, {collection(), metric()},
+        begin
+            Fun = fun(C) ->
+                {ok, Q, _V} = ?M:namespaces_query(Collection, Metric),
+                {Res, _} = epgsql:parse(C, Q),
+                Res
+            end,
+            ok =:= with_connection(Fun)
+        end
+    ).
+
+prop_tags() ->
+    ?FORALL({Collection, Namespace}, {collection(), namespace()},
+        begin
+            Fun = fun(C) ->
+                {ok, Q, _V} = ?M:tags_query(Collection, Namespace),
+                {Res, _} = epgsql:parse(C, Q),
+                Res
+            end,
+            ok =:= with_connection(Fun)
+        end
+    ).
+
+prop_metric_tags() ->
+    ?FORALL({Collection, Metric, Namespace}, {collection(), metric(),
+                                              namespace()},
+        begin
+            Fun = fun(C) ->
+                {ok, Q, _V} = ?M:tags_query(Collection, Metric, Namespace),
+                {Res, _} = epgsql:parse(C, Q),
+                Res
+            end,
+            ok =:= with_connection(Fun)
+        end
+    ).
+
+prop_values() ->
+    ?FORALL({Collection, Namespace, Tag}, {collection(), namespace(),
+                                           tag_name()},
+        begin
+            Fun = fun(C) ->
+                {ok, Q, _V} = ?M:values_query(Collection, Namespace, Tag),
+                {Res, _} = epgsql:parse(C, Q),
+                Res
+            end,
+            ok =:= with_connection(Fun)
+        end
+    ).
+
+prop_metric_values() ->
+    ?FORALL({Collection, Metric, Namespace, Tag}, {collection(), metric(),
+                                                   namespace(), tag_name()},
+        begin
+            Fun = fun(C) ->
+                {ok, Q, _V} = ?M:values_query(Collection, Metric,
+                                              Namespace, Tag),
                 {Res, _} = epgsql:parse(C, Q),
                 Res
             end,

--- a/src/dqe_idx_pg.erl
+++ b/src/dqe_idx_pg.erl
@@ -45,7 +45,7 @@ lookup_tags(Query) ->
 metric_variants(Collection, Prefix) when is_list(Prefix) ->
     {ok, Q, Vs} = query_builder:metric_variants_query(Collection, Prefix),
     Rows = execute({select, "metric_variants/2", Q, Vs}),
-    {ok, lists:sort(Rows)}.
+    {ok, [R || {R} <- lists:sort(Rows)]}.
 
 collections() ->
     {ok, Q, Vs} = query_builder:collections_query(),

--- a/src/dqe_idx_pg.erl
+++ b/src/dqe_idx_pg.erl
@@ -27,195 +27,66 @@ init() ->
 
 lookup(Query) ->
     {ok, Q, Vs} = query_builder:lookup_query(Query, []),
-    T0 = erlang:system_time(),
-    {ok, _Cols, Rows} = pgapp:equery(Q, Vs),
-    lager:debug("[dqe_idx:pg:lookup/2] Query took ~pms: ~s <- ~p",
-                [tdelta(T0), Q, Vs]),
+    Rows = execute({select, "lookup/1", Q, Vs}),
     R = [{B, dproto:metric_from_list(M)} || {B, M} <- Rows],
     {ok, R}.
 
 lookup(Query, Groupings) ->
     {ok, Q, Vs} = query_builder:lookup_query(Query, Groupings),
-    T0 = erlang:system_time(),
-    {ok, _Cols, Rows} = pgapp:equery(Q, Vs),
-    lager:debug("[dqe_idx:pg:lookup/2] Query took ~pms: ~s <- ~p",
-                [tdelta(T0), Q, Vs]),
+    Rows = execute({select, "lookup/2", Q, Vs}),
     R = [{B, dproto:metric_from_list(M), G} || {B, M, G} <- Rows],
     {ok, R}.
 
 lookup_tags(Query) ->
     {ok, Q, Vs} = query_builder:lookup_tags_query(Query),
-    T0 = erlang:system_time(),
-    {ok, _Cols, Rows} = pgapp:equery(Q, Vs),
-    lager:debug("[dqe_idx:pg:lookup/1] Query took ~pms: ~s <- ~p",
-                [tdelta(T0), Q, Vs]),
+    Rows = execute({select, "lookup_tags/1", Q, Vs}),
     {ok, Rows}.
 
 metric_variants(Collection, Prefix) when is_list(Prefix) ->
     {ok, Q, Vs} = query_builder:metric_variants_query(Collection, Prefix),
-    T0 = erlang:system_time(),
-    {ok, _Cols, Rows} = pgapp:equery(Q, Vs),
-    lager:debug("[dqe_idx:pg:metric_variants/2] Query took ~pms: ~s <- ~p",
-                [tdelta(T0), Q, Vs]),
+    Rows = execute({select, "metric_variants/2", Q, Vs}),
     {ok, lists:sort(Rows)}.
 
 collections() ->
-    Q = "WITH RECURSIVE t AS ("
-        "   SELECT MIN(collection) AS collection FROM " ?MET_TABLE
-        "   UNION ALL"
-        "   SELECT (SELECT MIN(collection) FROM " ?MET_TABLE
-        "     WHERE collection > t.collection)"
-        "   FROM t WHERE t.collection IS NOT NULL"
-        "   )"
-        "SELECT collection FROM t WHERE collection IS NOT NULL",
-    Vs = [],
-    T0 = erlang:system_time(),
-    {ok, _Cols, Rows} = pgapp:equery(Q, Vs),
-    lager:debug("[dqe_idx:pg:collections] Query took ~pms: ~s",
-                [tdelta(T0), Q]),
+    {ok, Q, Vs} = query_builder:collections_query(),
+    Rows = execute({select, "collections/0", Q, Vs}),
     {ok, strip_tpl(Rows)}.
 
-metrics(Collection) when is_binary(Collection) ->
-    Q = "WITH RECURSIVE t AS ("
-        "   SELECT MIN(metric) AS metric FROM "
-        ?MET_TABLE
-        "     WHERE collection = $1"
-        "   UNION ALL"
-        "   SELECT (SELECT MIN(metric) FROM "
-        ?MET_TABLE
-        "     WHERE metric > t.metric"
-        "     AND collection = $1)"
-        "   FROM t WHERE t.metric IS NOT NULL"
-        "   )"
-        "SELECT metric FROM t WHERE metric IS NOT NULL",
-    Vs = [Collection],
-    T0 = erlang:system_time(),
-    {ok, _Cols, Rows} = pgapp:equery(Q, Vs),
-    lager:debug("[dqe_idx:pg:metrics] Query took ~pms: ~s <- ~p",
-                [tdelta(T0), Q, Vs]),
+metrics(Collection) ->
+    {ok, Q, Vs} = query_builder:metrics_query(Collection),
+    Rows = execute({select, "metrics/1", Q, Vs}),
     R = [dproto:metric_from_list(M) || {M} <- Rows],
     {ok, R}.
 
-namespaces(Collection) when is_binary(Collection) ->
-    Q = "WITH RECURSIVE t AS ("
-        "   SELECT MIN(namespace) AS namespace FROM "
-        ?DIM_TABLE
-        "     WHERE collection = $1"
-        "   UNION ALL"
-        "   SELECT (SELECT MIN(namespace) FROM "
-        ?DIM_TABLE
-        "     WHERE namespace > t.namespace"
-        "     AND collection = $1)"
-        "   FROM t WHERE t.namespace IS NOT NULL"
-        "   )"
-        "SELECT namespace FROM t WHERE namespace IS NOT NULL",
-    Vs = [Collection],
-    T0 = erlang:system_time(),
-    {ok, _Cols, Rows} = pgapp:equery(Q, Vs),
-    lager:debug("[dqe_idx:pg:namespaces] Query took ~pms: ~s <- ~p",
-               [tdelta(T0), Q, Vs]),
+namespaces(Collection) ->
+    {ok, Q, Vs} = query_builder:namespaces_query(Collection),
+    Rows = execute({select, "namespaces/1", Q, Vs}),
     {ok, strip_tpl(Rows)}.
 
-namespaces(Collection, Metric) when is_binary(Metric) ->
-    namespaces(Collection, dproto:metric_to_list(Metric));
-
-namespaces(Collection, Metric)
-  when is_binary(Collection),
-       is_list(Metric) ->
-    Q = "SELECT DISTINCT(namespace) FROM " ?DIM_TABLE " "
-        "LEFT JOIN " ?MET_TABLE " "
-        "ON " ?DIM_TABLE ".metric_id = " ?MET_TABLE ".id "
-        "WHERE " ?MET_TABLE ".collection = $1 AND " ?MET_TABLE ".metric = $2",
-    Vs = [Collection, Metric],
-    T0 = erlang:system_time(),
-    {ok, _Cols, Rows} = pgapp:equery(Q, Vs),
-    lager:debug("[dqe_idx:pg:namespaces] Query took ~pms: ~s <- ~p",
-                [tdelta(T0), Q, Vs]),
+namespaces(Collection, Metric) ->
+    {ok, Q, Vs} = query_builder:namespaces_query(Collection, Metric),
+    Rows = execute({select, "namespaces/2", Q, Vs}),
     {ok, strip_tpl(Rows)}.
 
-tags(Collection, Namespace)
-  when is_binary(Collection),
-       is_binary(Namespace) ->
-    Q = "WITH RECURSIVE t AS ("
-        "   SELECT MIN(name) AS name FROM " ?DIM_TABLE
-        "     WHERE collection = $1"
-        "     AND namespace = $2"
-        "   UNION ALL"
-        "   SELECT (SELECT MIN(name) FROM " ?DIM_TABLE
-        "     WHERE name > t.name"
-        "     AND collection = $1"
-        "     AND namespace = $2)"
-        "   FROM t WHERE t.name IS NOT NULL"
-        "   )"
-        "SELECT name FROM t WHERE name IS NOT NULL",
-    Vs = [Collection, Namespace],
-    T0 = erlang:system_time(),
-    {ok, _Cols, Rows} = pgapp:equery(Q, Vs),
-    lager:debug("[dqe_idx:pg:tags/3] Query took ~pms: ~s <- ~p",
-                [tdelta(T0), Q, Vs]),
-    {ok, strip_tpl(Rows)}.
-tags(Collection, Metric, Namespace) when is_binary(Metric)->
-    tags(Collection, dproto:metric_to_list(Metric), Namespace);
-
-tags(Collection, Metric, Namespace)
-  when is_binary(Collection),
-       is_list(Metric),
-       is_binary(Namespace) ->
-    Q = "SELECT DISTINCT(name) FROM " ?DIM_TABLE " "
-        "LEFT JOIN " ?MET_TABLE " "
-        "ON " ?DIM_TABLE ".metric_id = " ?MET_TABLE ".id "
-        "WHERE " ?MET_TABLE ".collection = $1 AND " ?MET_TABLE ".metric = $2 "
-        "AND " ?DIM_TABLE ".namespace = $3",
-    Vs = [Collection, Metric, Namespace],
-    T0 = erlang:system_time(),
-    {ok, _Cols, Rows} = pgapp:equery(Q, Vs),
-    lager:debug("[dqe_idx:pg:tags/3] Query took ~pms: ~s <- ~p",
-                [tdelta(T0), Q, Vs]),
+tags(Collection, Namespace) ->
+    {ok, Q, Vs} = query_builder:tags_query(Collection, Namespace),
+    Rows = execute({select, "tags/2", Q, Vs}),
     {ok, strip_tpl(Rows)}.
 
-values(Collection, Namespace, Tag)
-  when is_binary(Collection),
-       is_binary(Namespace),
-       is_binary(Tag) ->
-    Q = "WITH RECURSIVE t AS ("
-        "   SELECT MIN(value) AS value FROM " ?DIM_TABLE
-        "     WHERE collection = $1"
-        "     AND namespace = $2"
-        "     AND name = $3"
-        "   UNION ALL"
-        "   SELECT (SELECT MIN(value) FROM " ?DIM_TABLE
-        "     WHERE value > t.value"
-        "     AND collection = $1"
-        "     AND namespace = $2"
-        "     AND name = $3)"
-        "   FROM t WHERE t.value IS NOT NULL"
-        "   )"
-        "SELECT value FROM t WHERE value IS NOT NULL",
-    Vs = [Collection, Namespace, Tag],
-    T0 = erlang:system_time(),
-    {ok, _Cols, Rows} = pgapp:equery(Q, Vs),
-    lager:debug("[dqe_idx:pg:values/4] Query took ~pms: ~s <- ~p",
-                [tdelta(T0), Q, Vs]),
+tags(Collection, Metric, Namespace) ->
+    {ok, Q, Vs} = query_builder:tags_query(Collection, Metric, Namespace),
+    Rows = execute({select, "tags/3", Q, Vs}),
     {ok, strip_tpl(Rows)}.
 
-values(Collection, Metric, Namespace, Tag) when is_binary(Metric)->
-    values(Collection, dproto:metric_to_list(Metric), Namespace, Tag);
+values(Collection, Namespace, Tag) ->
+    {ok, Q, Vs} = query_builder:values_query(Collection, Namespace, Tag),
+    Rows = execute({select, "values/3", Q, Vs}),
+    {ok, strip_tpl(Rows)}.
 
-values(Collection, Metric, Namespace, Tag)
-  when is_binary(Collection),
-       is_list(Metric),
-       is_binary(Namespace),
-       is_binary(Tag) ->
-    Q = "SELECT DISTINCT(value) FROM " ?DIM_TABLE " "
-        "LEFT JOIN " ?MET_TABLE " "
-        "ON " ?DIM_TABLE ".metric_id = " ?MET_TABLE ".id "
-        "WHERE " ?MET_TABLE ".collection = $1 AND " ?MET_TABLE ".metric = $2 "
-        "AND " ?DIM_TABLE ".namespace = $3 AND name = $4",
-    Vs = [Collection, Metric, Namespace, Tag],
-    T0 = erlang:system_time(),
-    {ok, _Cols, Rows} = pgapp:equery(Q, Vs),
-    lager:debug("[dqe_idx:pg:values/4] Query took ~pms: ~s <- ~p",
-                [tdelta(T0), Q, Vs]),
+values(Collection, Metric, Namespace, Tag) ->
+    {ok, Q, Vs} = query_builder:values_query(Collection, Metric,
+                                             Namespace, Tag),
+    Rows = execute({select, "values/4", Q, Vs}),
     {ok, strip_tpl(Rows)}.
 
 expand(Bucket, []) when is_binary(Bucket) ->
@@ -226,11 +97,7 @@ expand(Bucket, Globs) when
       is_list(Globs) ->
     {ok, QueryMap} = query_builder:glob_query(Bucket, Globs),
     RowSets = [begin
-                   T0 = erlang:system_time(),
-                   {ok, _Cols, Rows} = pgapp:equery(Q, Vs),
-                   lager:debug("[dqe_idx:pg:expand/2] "
-                               "Query took ~p ms: ~s <- ~p",
-                               [tdelta(T0), Q, Vs]),
+                   Rows = execute({select, "expand/2", Q, Vs}),
                    sets:from_list(Rows)
                end || {Q, Vs} <- QueryMap],
 
@@ -466,3 +333,10 @@ tag_values(P)  ->
      "$", query_builder:i2l(P + 2), ", "
      "$", query_builder:i2l(P + 3), ", "
      "$", query_builder:i2l(P + 4), ")"].
+
+execute({select, Name, Q, Vs}) ->
+    T0 = erlang:system_time(),
+    {ok, _Cols, Rows} = pgapp:equery(Q, Vs),
+    lager:debug("[dqe_idx:pg:~p] Query took ~pms: ~s <- ~p",
+                [Name, tdelta(T0), Q, Vs]),
+    Rows.

--- a/src/query_builder.erl
+++ b/src/query_builder.erl
@@ -120,12 +120,12 @@ glob_query(Bucket, Globs) ->
 metric_variants_query(Collection, Prefix)
   when is_binary(Collection),
        is_list(Prefix) ->
-    L = length(Prefix),
-    {_N, MetricVals, MetricPredicate} = metric_variant_where(Prefix, 3),
-    Query = ["SELECT DISTINCT metric[$1] ",
+    {_N, MetricVals, MetricPredicate} = metric_variant_where(Prefix, 4),
+    Query = ["SELECT DISTINCT metric[$1]",
              "FROM ", ?MET_TABLE, " ",
-             "WHERE collection = $2 "],
-    Values = [L + 1, Collection | MetricVals],
+             "WHERE metric[$2] IS NOT NULL AND collection = $3 "],
+    PathIndex = 1 + length(Prefix),
+    Values = [PathIndex, PathIndex, Collection | MetricVals],
     {ok, Query ++ MetricPredicate, Values}.
 
 tags_query(Collection, Namespace)

--- a/src/query_builder.erl
+++ b/src/query_builder.erl
@@ -1,12 +1,76 @@
 -module(query_builder).
--export([lookup_query/2, lookup_tags_query/1, add_tags/2, update_tags/2,
-         glob_query/2, metric_variants_query/2, i2l/1]).
+
+-export([collections_query/0, metrics_query/1, metric_variants_query/2,
+         namespaces_query/1, namespaces_query/2,
+         lookup_query/2, lookup_tags_query/1,
+         tags_query/2, tags_query/3, add_tags/2, update_tags/2,
+         values_query/3, values_query/4,
+         glob_query/2, i2l/1]).
 
 -include("dqe_idx_pg.hrl").
 
 %%====================================================================
 %% API
 %%====================================================================
+
+collections_query() ->
+    Query = "WITH RECURSIVE t AS ("
+            "   SELECT MIN(collection) AS collection FROM " ?MET_TABLE
+            "   UNION ALL"
+            "   SELECT (SELECT MIN(collection) FROM " ?MET_TABLE
+            "     WHERE collection > t.collection)"
+            "   FROM t WHERE t.collection IS NOT NULL"
+            "   )"
+            "SELECT collection FROM t WHERE collection IS NOT NULL",
+    Values = [],
+    {ok, Query, Values}.
+
+metrics_query(Collection)
+  when is_binary(Collection) ->
+    Query = "WITH RECURSIVE t AS ("
+            "   SELECT MIN(metric) AS metric FROM "
+            ?MET_TABLE
+            "     WHERE collection = $1"
+            "   UNION ALL"
+            "   SELECT (SELECT MIN(metric) FROM "
+            ?MET_TABLE
+            "     WHERE metric > t.metric"
+            "     AND collection = $1)"
+            "   FROM t WHERE t.metric IS NOT NULL"
+            "   )"
+            "SELECT metric FROM t WHERE metric IS NOT NULL",
+    Values = [Collection],
+    {ok, Query, Values}.
+
+namespaces_query(Collection)
+  when is_binary(Collection) ->
+    Query = "WITH RECURSIVE t AS ("
+            "   SELECT MIN(namespace) AS namespace FROM "
+            ?DIM_TABLE
+            "     WHERE collection = $1"
+            "   UNION ALL"
+            "   SELECT (SELECT MIN(namespace) FROM "
+            ?DIM_TABLE
+            "     WHERE namespace > t.namespace"
+            "     AND collection = $1)"
+            "   FROM t WHERE t.namespace IS NOT NULL"
+            "   )"
+            "SELECT namespace FROM t WHERE namespace IS NOT NULL",
+    Values = [Collection],
+    {ok, Query, Values}.
+
+namespaces_query(Collection, Metric) when is_binary(Metric) ->
+    namespaces_query(Collection, dproto:metric_to_list(Metric));
+
+namespaces_query(Collection, Metric)
+  when is_binary(Collection),
+       is_list(Metric) ->
+    Q = "SELECT DISTINCT(namespace) FROM " ?DIM_TABLE " "
+        "LEFT JOIN " ?MET_TABLE " "
+        "ON " ?DIM_TABLE ".metric_id = " ?MET_TABLE ".id "
+        "WHERE " ?MET_TABLE ".collection = $1 AND " ?MET_TABLE ".metric = $2",
+    Vs = [Collection, Metric],
+    {ok, Q, Vs}.
 
 lookup_query({in, Collection, Metric}, Groupings)
   when is_binary(Metric) ->
@@ -20,6 +84,134 @@ lookup_query({in, Collection, Metric}, Groupings) ->
     build_lookup_query(Collection, Metric, Groupings);
 lookup_query({in, Bucket, Metric, Where}, Groupings) ->
     build_lookup_query(Bucket, Metric, Where, Groupings).
+
+lookup_tags_query({in, Collection, Metric}) when is_binary(Metric) ->
+    lookup_tags_query({in, Collection, dproto:metric_to_list(Metric)});
+lookup_tags_query({in, Collection, Metric, Where}) when is_binary(Metric) ->
+    lookup_tags_query({in, Collection, dproto:metric_to_list(Metric), Where});
+lookup_tags_query({in, Collection, Metric})
+  when is_list(Metric) ->
+    Query = "SELECT DISTINCT namespace, name, value "
+        "FROM " ?DIM_TABLE " "
+        "LEFT JOIN " ?MET_TABLE " ON "
+        ?DIM_TABLE ".metric_id = " ?MET_TABLE ".id "
+        "WHERE " ?MET_TABLE ".collection = $1 and metric = $2",
+    Values = [Collection, Metric],
+    {ok, Query, Values};
+lookup_tags_query({in, Bucket, Metric, Where})
+  when is_list(Metric) ->
+    Query = "SELECT DISTINCT namespace, name, value "
+        "FROM " ?DIM_TABLE " "
+        "LEFT JOIN " ?MET_TABLE " ON "
+        ?DIM_TABLE ".metric_id = id "
+        "WHERE " ?MET_TABLE ".collection = $1 and metric = $2"
+        "AND ",
+    {_N, TagPairs, TagPredicate} = build_tag_lookup(Where),
+    Values = [Bucket, Metric | TagPairs],
+    {ok, Query ++ TagPredicate, Values}.
+
+glob_query(Bucket, Globs) ->
+    Query = ["SELECT DISTINCT key ",
+             "FROM ", ?MET_TABLE, " ",
+             "WHERE bucket = $1 AND "],
+    GlobWheres = [glob_where(Bucket, Query, Glob) || Glob <- Globs],
+    {ok, GlobWheres}.
+
+metric_variants_query(Collection, Prefix)
+  when is_binary(Collection),
+       is_list(Prefix) ->
+    L = length(Prefix),
+    {_N, MetricVals, MetricPredicate} = metric_variant_where(Prefix, 3),
+    Query = ["SELECT DISTINCT metric[$1] ",
+             "FROM ", ?MET_TABLE, " ",
+             "WHERE collection = $2 "],
+    Values = [L + 1, Collection | MetricVals],
+    {ok, Query ++ MetricPredicate, Values}.
+
+tags_query(Collection, Namespace)
+  when is_binary(Collection),
+       is_binary(Namespace) ->
+    Q = "WITH RECURSIVE t AS ("
+        "   SELECT MIN(name) AS name FROM " ?DIM_TABLE
+        "     WHERE collection = $1"
+        "     AND namespace = $2"
+        "   UNION ALL"
+        "   SELECT (SELECT MIN(name) FROM " ?DIM_TABLE
+        "     WHERE name > t.name"
+        "     AND collection = $1"
+        "     AND namespace = $2)"
+        "   FROM t WHERE t.name IS NOT NULL"
+        "   )"
+        "SELECT name FROM t WHERE name IS NOT NULL",
+    Vs = [Collection, Namespace],
+    {ok, Q, Vs}.
+
+tags_query(Collection, Metric, Namespace)
+  when is_binary(Metric) ->
+    tags_query(Collection, dproto:metric_to_list(Metric), Namespace);
+
+tags_query(Collection, Metric, Namespace)
+  when is_binary(Collection),
+       is_list(Metric),
+       is_binary(Namespace) ->
+    Q = "SELECT DISTINCT(name) FROM " ?DIM_TABLE " "
+        "LEFT JOIN " ?MET_TABLE " "
+        "ON " ?DIM_TABLE ".metric_id = " ?MET_TABLE ".id "
+        "WHERE " ?MET_TABLE ".collection = $1 AND " ?MET_TABLE ".metric = $2 "
+        "AND " ?DIM_TABLE ".namespace = $3",
+    Vs = [Collection, Metric, Namespace],
+    {ok, Q, Vs}.
+
+
+add_tags(MID, Tags) ->
+    Fn = "add_tag",
+    build_add_tags(MID, 1, Fn, Tags, "SELECT", []).
+
+update_tags(MID, Tags) ->
+    Fn = "update_tag",
+    build_add_tags(MID, 1, Fn, Tags, "SELECT", []).
+
+values_query(Collection, Namespace, Tag)
+  when is_binary(Collection),
+       is_binary(Namespace),
+       is_binary(Tag) ->
+    Q = "WITH RECURSIVE t AS ("
+        "   SELECT MIN(value) AS value FROM " ?DIM_TABLE
+        "     WHERE collection = $1"
+        "     AND namespace = $2"
+        "     AND name = $3"
+        "   UNION ALL"
+        "   SELECT (SELECT MIN(value) FROM " ?DIM_TABLE
+        "     WHERE value > t.value"
+        "     AND collection = $1"
+        "     AND namespace = $2"
+        "     AND name = $3)"
+        "   FROM t WHERE t.value IS NOT NULL"
+        "   )"
+        "SELECT value FROM t WHERE value IS NOT NULL",
+    Vs = [Collection, Namespace, Tag],
+    {ok, Q, Vs}.
+
+values_query(Collection, Metric, Namespace, Tag) when is_binary(Metric)->
+    values_query(Collection, dproto:metric_to_list(Metric), Namespace, Tag);
+
+values_query(Collection, Metric, Namespace, Tag)
+  when is_binary(Collection),
+       is_list(Metric),
+       is_binary(Namespace),
+       is_binary(Tag) ->
+    Q = "SELECT DISTINCT(value) FROM " ?DIM_TABLE " "
+        "LEFT JOIN " ?MET_TABLE " "
+        "ON " ?DIM_TABLE ".metric_id = " ?MET_TABLE ".id "
+        "WHERE " ?MET_TABLE ".collection = $1 AND " ?MET_TABLE ".metric = $2 "
+        "AND " ?DIM_TABLE ".namespace = $3 AND name = $4",
+    Vs = [Collection, Metric, Namespace, Tag],
+    {ok, Q, Vs}.
+
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
 
 build_lookup_query(Collection, Metric, Grouping)
   when is_list(Metric); Metric =:= undefined ->
@@ -59,73 +251,6 @@ build_lookup_query(Bucket, Metric, Where, Grouping)
                                      {Namespace, Name} <- Grouping]),
     Values = [Bucket | MetricName ++ FlatGrouping ++ TagPairs],
     {ok, Query ++ TagPredicate, Values}.
-
-lookup_tags_query({in, Collection, Metric}) when is_binary(Metric) ->
-    lookup_tags_query({in, Collection, dproto:metric_to_list(Metric)});
-lookup_tags_query({in, Collection, Metric, Where}) when is_binary(Metric) ->
-    lookup_tags_query({in, Collection, dproto:metric_to_list(Metric), Where});
-lookup_tags_query({in, Collection, Metric})
-  when is_list(Metric) ->
-    Query = "SELECT DISTINCT namespace, name, value "
-        "FROM " ?DIM_TABLE " "
-        "LEFT JOIN " ?MET_TABLE " ON "
-        ?DIM_TABLE ".metric_id = " ?MET_TABLE ".id "
-        "WHERE " ?MET_TABLE ".collection = $1 and metric = $2",
-    Values = [Collection, Metric],
-    {ok, Query, Values};
-lookup_tags_query({in, Bucket, Metric, Where})
-  when is_list(Metric) ->
-    Query = "SELECT DISTINCT namespace, name, value "
-        "FROM " ?DIM_TABLE " "
-        "LEFT JOIN " ?MET_TABLE " ON "
-        ?DIM_TABLE ".metric_id = id "
-        "WHERE " ?MET_TABLE ".collection = $1 and metric = $2"
-        "AND ",
-    {_N, TagPairs, TagPredicate} = build_tag_lookup(Where),
-    Values = [Bucket, Metric | TagPairs],
-    {ok, Query ++ TagPredicate, Values}.
-
-glob_query(Bucket, Globs) ->
-    Query = ["SELECT DISTINCT key ",
-             "FROM ", ?MET_TABLE, " ",
-             "WHERE bucket = $1 AND "],
-    GlobWheres = [glob_where(Bucket, Query, Glob) || Glob <- Globs],
-    {ok, GlobWheres}.
-
-metric_variants_query(Collection, Prefix) when is_list(Prefix) ->
-    L = length(Prefix),
-    {_N, MetricVals, MetricPredicate} = metric_variant_where(Prefix, 3),
-    Query = ["SELECT DISTINCT metric[$1] ",
-             "FROM ", ?MET_TABLE, " ",
-             "WHERE collection = $2 "],
-    Values = [L + 1, Collection | MetricVals],
-    {ok, Query ++ MetricPredicate, Values}.
-
-add_tags(MID, Tags) ->
-    Fn = "add_tag",
-    build_add_tags(MID, 1, Fn, Tags, "SELECT", []).
-
-build_add_tags(MID, P, Fn, [{NS, N, V}], Q, Vs) ->
-    {[Q, add_tag(Fn, P)], lists:reverse([V, N, NS, MID | Vs])};
-
-build_add_tags(MID, P, Fn, [{NS, N, V} | Tags], Q, Vs) ->
-    Q1 = [Q, add_tag(Fn, P), ","],
-    Vs1 = [V, N, NS, MID | Vs],
-    build_add_tags(MID, P+4, Fn, Tags, Q1, Vs1).
-
-add_tag(Fn, P)  ->
-    [" ", Fn, "($", i2l(P), ", "
-     "$", i2l(P + 1), ", "
-     "$", i2l(P + 2), ", "
-     "$", i2l(P + 3), ")"].
-
-update_tags(MID, Tags) ->
-    Fn = "update_tag",
-    build_add_tags(MID, 1, Fn, Tags, "SELECT", []).
-
-%%====================================================================
-%% Internal functions
-%%====================================================================
 
 glob_where(Bucket, Query, Glob) ->
     Where = and_tags(glob_to_tags(Glob)),
@@ -179,6 +304,20 @@ build_tag_lookup({'!=', {tag, NS, K}, V}, NIn, Vals) ->
            " AND name = $", i2l(NIn+1),
            " AND value = $", i2l(NIn+2), ")"],
     {NIn+3, [NS, K, V | Vals], Str}.
+
+build_add_tags(MID, P, Fn, [{NS, N, V}], Q, Vs) ->
+    {[Q, add_tag(Fn, P)], lists:reverse([V, N, NS, MID | Vs])};
+
+build_add_tags(MID, P, Fn, [{NS, N, V} | Tags], Q, Vs) ->
+    Q1 = [Q, add_tag(Fn, P), ","],
+    Vs1 = [V, N, NS, MID | Vs],
+    build_add_tags(MID, P+4, Fn, Tags, Q1, Vs1).
+
+add_tag(Fn, P)  ->
+    [" ", Fn, "($", i2l(P), ", "
+     "$", i2l(P + 1), ", "
+     "$", i2l(P + 2), ", "
+     "$", i2l(P + 3), ")"].
 
 grouping_names(0) ->
     [];


### PR DESCRIPTION
Includes move of SQL templates from pg module to the builder for consistency + tests.
