### PR TITLE
Result spec is a pair when 'returning' is absent

### DIFF
--- a/src/dqe_idx_pg.erl
+++ b/src/dqe_idx_pg.erl
@@ -176,7 +176,7 @@ update(Collection, Metric, Bucket, Key, NVs)
             {Q, Vs} = update_tags(MID, Collection, NVs),
             T0 = erlang:system_time(),
             case pgapp:equery(Q, Vs) of
-                {ok, _, _} ->
+                {ok, _Count} ->
                     lager:debug("[dqe_idx:pg:update/5] Query too ~pms:"
                                 " ~s <- ~p",
                                 [dqe_idx_pg:tdelta(T0), Q, Vs]),
@@ -232,7 +232,7 @@ delete(MetricID, Namespace, TagName) ->
         "namespace = $2 AND name = $3",
     Vs = [MetricID, Namespace, TagName],
     case pgapp:equery(Q, Vs) of
-        {ok, _, _} ->
+        {ok, _Count} ->
             ok;
         E ->
             E


### PR DESCRIPTION
According to the epgsql typespec, when no returning is used, only a count of the number of rows affected will be returned.
