### PR TITLE
Fix ordering of meta-data values requested by grouping

### DIFF
--- a/src/query_builder.erl
+++ b/src/query_builder.erl
@@ -129,7 +129,7 @@ lookup_query(Lookup, []) ->
 lookup_query(Lookup, KeysToRead) ->
     {Condition, CVals} = lookup_condition(Lookup),
     I = length(CVals),
-    Query = ["SELECT bucket, key, avals(slice(dimensions, $", i2l(I + 1), "))"
+    Query = ["SELECT bucket, key, slice(dimensions, $", i2l(I + 1), ")"
              "  FROM metrics WHERE " | Condition],
     Keys = [encode_tag_key(Ns, Name) || {Ns, Name} <- KeysToRead],
     Values = CVals ++ [Keys],


### PR DESCRIPTION
I realised, that hstore data structure does not preserve keys
order. There is no way to make sure that dimension values are returned
in the same order as they have been requested. I have changed query
builder to return full hstore qith dimensions we need and i unpack
values in erlang, preserving requested order.