### PR TITLE
Configurable worker timeout

### DIFF
--- a/priv/dqe_idx_pg.schema
+++ b/priv/dqe_idx_pg.schema
@@ -41,3 +41,8 @@
 {mapping, "idx.pg.password", "dqe_idx_pg.password",
  [{default, "ddb"},
   {datatype, string}]}.
+
+%% @doc How long a pool worker should wait before timing out
+{mapping, "idx.pg.timeout", "dqe_idx_pg.timeout",
+ [{default, 5000},
+  {datatype, integer}]}.

--- a/priv/dqe_idx_pg.schema
+++ b/priv/dqe_idx_pg.schema
@@ -44,5 +44,5 @@
 
 %% @doc How long a pool worker should wait before timing out
 {mapping, "idx.pg.timeout", "dqe_idx_pg.timeout",
- [{default, 5000},
-  {datatype, integer}]}.
+ [{default, "5s"},
+  {datatype, {time, ms}}]}.

--- a/src/dqe_idx_pg.erl
+++ b/src/dqe_idx_pg.erl
@@ -15,6 +15,8 @@
 
 -import(dqe_idx_pg_utils, [decode_ns/1, hstore_to_tags/1, kvpair_to_tag/1]).
 
+-define(TIMEOUT, 5 * 1000).
+
 %%====================================================================
 %% API functions
 %%====================================================================
@@ -195,13 +197,13 @@ decode_ns_rows(Rows) ->
 
 execute({select, Name, Q, Vs}) ->
     T0 = erlang:system_time(),
-    {ok, _Cols, Rows} = pgapp:equery(Q, Vs),
+    {ok, _Cols, Rows} = pgapp:equery(Q, Vs, timeout()),
     lager:debug("[dqe_idx:pg:~p] Query took ~pms: ~s <- ~p",
                 [Name, tdelta(T0), Q, Vs]),
     Rows;
 execute({command, Name, Q, Vs}) ->
     T0 = erlang:system_time(),
-    case pgapp:equery(Q, Vs) of
+    case pgapp:equery(Q, Vs, timeout()) of
         {ok, Count} ->
             lager:debug("[dqe_idx:pg:~p] Query took ~pms: ~s <- ~p",
                         [Name, tdelta(T0), Q, Vs]),
@@ -233,3 +235,6 @@ get_tag_value({Ns, Name}, [{TNs, TName, TValue} | _])
     TValue;
 get_tag_value(TagKey, [_ | Rest]) ->
     get_tag_value(TagKey, Rest).
+
+timeout() ->
+    application:get_env(dqe_idx_pg, timeout, ?TIMEOUT).


### PR DESCRIPTION
Allows clients to override the default gen_server worker timeout for long-running queries.