### PR TITLE
Monotonic updates

### DIFF
--- a/eqc/logic_eqc.erl
+++ b/eqc/logic_eqc.erl
@@ -39,7 +39,7 @@ prop_optimize() ->
     ?FORALL(
        L, logic(),
        begin
-           S = query_builder:simplify(L),
-           R = query_builder:interalize_and(S),
+           S = pg_query_builder:simplify(L),
+           R = pg_query_builder:interalize_and(S),
            eval_logic(L) =:= eval_logic(R)
        end).

--- a/eqc/pg_command_builder_eqc.erl
+++ b/eqc/pg_command_builder_eqc.erl
@@ -1,4 +1,4 @@
--module(command_builder_eqc).
+-module(pg_command_builder_eqc).
 
 -include_lib("eqc/include/eqc.hrl").
 
@@ -8,7 +8,7 @@
                      tag_name/0, namespace/0, non_empty_list/1,
                      with_connection/1]).
 
--define(M, command_builder).
+-define(M, pg_command_builder).
 
 timestamp() ->
     oneof([now, undefined, nat()]).

--- a/eqc/pg_query_builder_eqc.erl
+++ b/eqc/pg_query_builder_eqc.erl
@@ -1,4 +1,4 @@
--module(query_builder_eqc).
+-module(pg_query_builder_eqc).
 
 -include_lib("eqc/include/eqc.hrl").
 
@@ -7,7 +7,7 @@
 -import(eqc_helper, [lookup/0, lookup_tags/0, collection/0, prefix/0, pos_int/0,
                      metric/0, namespace/0, tag_name/0, with_connection/1]).
 
--define(M, query_builder).
+-define(M, pg_query_builder).
 
 %%%-------------------------------------------------------------------
 %%% Properties

--- a/src/pg_command_builder.erl
+++ b/src/pg_command_builder.erl
@@ -1,4 +1,4 @@
--module(command_builder).
+-module(pg_command_builder).
 
 -export([touch/1,
          add_metric/6,

--- a/src/pg_command_builder.erl
+++ b/src/pg_command_builder.erl
@@ -62,7 +62,8 @@ touch(Points) ->
     Query = "UPDATE metrics AS m SET"
         "  time_range = tsrange(lower(time_range), p.last_seen) "
         "FROM (VALUES " ++ Values ++ ") as p(bucket, key, last_seen) "
-        "WHERE m.bucket = p.bucket AND m.key = p.key",
+        "WHERE m.bucket = p.bucket AND m.key = p.key "
+        "AND p.last_seen > upper(time_range)",
     {ok, Query, Data}.
 
 -spec delete_metric(dqe_idx:collection(),

--- a/src/pg_query_builder.erl
+++ b/src/pg_query_builder.erl
@@ -1,4 +1,4 @@
--module(query_builder).
+-module(pg_query_builder).
 
 -export([collections_query/0, metrics_query/1, metrics_query/2, metrics_query/3,
          namespaces_query/1, namespaces_query/2,


### PR DESCRIPTION
Ensures updates to the last seen time always increase monotically when using the touch function.

This is necessary to allow the processing of stragglers in a metadata stream that could have a timestamp that precedes the last_seen in the metrics table.