### PR TITLE
Change time unit to v18 compatible unit

### DIFF
--- a/eqc/pg_query_builder_eqc.erl
+++ b/eqc/pg_query_builder_eqc.erl
@@ -21,7 +21,7 @@ prop_lookup() ->
           begin
               Fun =
                   fun(C) ->
-                          Start = erlang:system_time(millisecond),
+                          Start = erlang:system_time(milli_seconds),
                           Finish = Start + Delta,
                           {ok, Q, _V} = ?M:lookup_query(LQuery, Start, Finish, []),
                           {Res, _} = epgsql:parse(C, Q),

--- a/src/dqe_idx_pg.erl
+++ b/src/dqe_idx_pg.erl
@@ -289,7 +289,7 @@ timeout() ->
 date_to_ms({Date , {H, M, S}}) ->
     GSecs = calendar:datetime_to_gregorian_seconds({Date, {H, M, round(S)}}),
     Secs = GSecs - ?S1970,
-    erlang:convert_time_unit(Secs, second, millisecond).
+    erlang:convert_time_unit(Secs, seconds, milli_seconds).
 
 translate_row({B, K, StartD, FinishD}, Start, Finish, Grace) ->
     StartMSG = date_to_ms(StartD) - Grace,

--- a/src/dqe_idx_pg_utils.erl
+++ b/src/dqe_idx_pg_utils.erl
@@ -49,7 +49,7 @@ kvpair_to_tag({Key, Value}) ->
     {Ns, Name, Value}.
 
 ms_to_date(MS) ->
-    S = erlang:convert_time_unit(MS, millisecond, second),
+    S = erlang:convert_time_unit(MS, milli_seconds, seconds),
     s_to_date(S).
 
 s_to_date(S) ->


### PR DESCRIPTION
Currently, the 7.2 erts fails on these calls with a `badarg`.  My assumption in this PR is that there is backwards compatibility for these with erlang 19, and we can use one release to move off these time  units.